### PR TITLE
Documentation improvements and redesign : objectstyle-private/marketing/agrest#3

### DIFF
--- a/app/styles/_docs.scss
+++ b/app/styles/_docs.scss
@@ -1,4 +1,5 @@
 .documentation-page {
+  font-size: .875rem;
 
   .toc {
     display: block !important; // overwrite docbook style
@@ -9,7 +10,7 @@
 
     .sectlevel2 {
         padding-left: 10px;
-        font-size: $small-font-size;
+        // font-size: $small-font-size;
     }
   }
 
@@ -22,7 +23,7 @@
   		// 0 level links
   		.cd-toc-link {
   			display: inline-block;
-  	        padding: .5rem 2rem .5rem .5rem;
+  	        padding: .5rem 2rem .5rem 0;
       		line-height: 1.1;
 
   			&.active {
@@ -32,10 +33,9 @@
 
   	    // Active states
   	    .nav-link {
+          // font-size: 0.95rem;
 
-            font-size: 0.95rem;
-
-  		    &.active {
+          &.active {
   		    	position: relative;
 
   		    	&:before {
@@ -69,7 +69,7 @@
 
   			// ul 1st level
   			.sectlevel1 {
-  				padding: 0 2rem 0 .75rem;
+  				padding: 0 2rem 0 0;
   				margin-bottom: 0;
   			}
 
@@ -101,6 +101,70 @@
   		}
   }
 
+  // conum (callout nummber from code)
+  .conum[data-value],
+  .hljs-number {
+    // font-size: .875rem;
+    // font-style: normal;
+    // background: $body-color;
+    // color: $white;
+    // display: inline-flex;
+    // justify-content: center;
+    // align-items: center;
+    // min-width: 1.7143em;        //  = 24px from 14px
+    // height: 1.7143em;           //  = 24px from 14px
+    // border-radius: 50rem;
+    
+    &:after {
+      content: attr(data-value);
+      position: relative;
+      left: -0.5px;
+    }
+    
+    & + b {
+      display: none;
+    }
+    
+    // number for now but useless, only to demo
+    background: #d36363;
+    color: #fff;
+    width: 21px;
+    height: 21px;
+    display: inline-block;
+    vertical-align: middle;
+    text-align: center;
+    line-height: 21px;
+    font-style: normal;
+    border-radius: 50rem;
+    margin-right: -0.5em;
+    margin-left: -0.5em;
+    position: relative;
+  }
+  
+  // colist (callout list)
+  .colist table {
+    border: none;
+
+    tr td:first-child {
+      padding-right: 0.35em;
+    }
+
+    tr:last-child td {
+      padding-bottom: 0;
+    }
+    
+    td {
+      border: none;
+      vertical-align: top;
+      padding-left: 0;
+      font-size: 14px;
+      
+      .conum[data-value] {
+        margin: -.25em .2857em auto;       // = 4px from 14px
+      }
+    }
+    
+  }
 
   table {
     border-collapse: collapse;
@@ -118,9 +182,9 @@
 
     caption {
       color: #000;
-      font: italic 85%/1 arial, sans-serif;
+      font: italic 100%/1 arial, sans-serif;
       padding: 1em 0;
-      text-align: center;
+      caption-side: top;
     }
 
     td, th {
@@ -143,6 +207,12 @@
     tbody > tr:last-child > td {
       border-bottom-width: 0;
     }
+  }
+
+  .title {
+    color: #000;
+    font: italic 100%/1 arial, sans-serif;
+    padding: 1em 0 .75em;
   }
 }
 
@@ -238,6 +308,8 @@
     }
   }
 
+  
+
   h1 {
       text-align: center;
   }
@@ -266,12 +338,22 @@
 
   h2 {
     font-size:1.7rem;
+    margin-top: 0 !important;
+    margin-bottom: 0.5em !important;
+  }
+
+  * + .sect1 h2 {
+    margin-top: 3rem !important;
   }
 
   h3 {
     font-size: 1.4rem;
-    margin-bottom: 1rem;
-    margin-top: 3rem;
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  
+  .sect2:not(:first-child) h3 {
+    margin-top: 2rem !important;
   }
 
   h4 {
@@ -283,4 +365,53 @@
   .cd-content {
       font-size: 0.95rem;
   }
+
+  .imageblock img {
+    @extend .img-fluid;
+  }
+
+  .anchor {
+    position:absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    pointer-events: auto;
+    z-index: 1;
+
+    display: inline-block;
+    vertical-align: top;
+    
+    height: inherit;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    display: var(--fa-display,inline-block);
+    font-style: normal;
+    font-variant: normal;
+    line-height: 1;
+    text-rendering: auto;-moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    display: var(--fa-display,inline-block);
+    font-style: normal;
+    font-variant: normal;
+    line-height: 1;
+    text-rendering: auto;
+
+    font-family: var(--fa-style-family,"Font Awesome 6 Free");
+    font-weight: var(--fa-style,900);
+}
+
+.anchor:hover:before {
+    opacity:1;
+}
+
+.anchor:before {
+    position:absolute;
+    right: calc(100% + .75em);
+    top: 9px;
+    font-size: 16px;
+    color: #707070;
+    content: "\f0c1";
+    opacity: 0;
+    transition: all .2s linear;}
 }

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -179,4 +179,12 @@ $modal-sm:                          300px !default;
 
 $modal-transition:                  transform .3s ease-out !default;
 
+
+// Code
+
+$code-font-size:                    100%;
+
+
+// FontAwesome
+
 $fa-font-path: "~@fortawesome/fontawesome-free/webfonts/";

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -194,8 +194,8 @@ $i: "../images/"; // PATH VAR
 		border-radius: calculateRem(5px);
 		display: inline-block;
 		overflow: visible;
-		padding: .05em .4em;
-		margin: .05em 0;
+		padding: 0em 0.4em;
+		line-height: 1.5;
 
 		a > &,
 		h1 > &, h2 > &, h3 > &, h4 > &, h5 > &, h6 > &,

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -9,12 +9,12 @@
             {{ partial "version_selector.gohtml" . }}
         <hr/>
 
-        <div class="row ">
+        <div class="row mx-0">
             <div id="docs-nav" class="col-12 col-lg-4 col-xl-3 nav  docs-nav">
                 {{ partial "sidebar-single.gohtml" . }}
             </div>
 
-            <div class="col-12 col-lg-8 col-xl-9  py-3 pl-lg-5">
+            <div class="col-12 col-lg-8 col-xl-9  pb-3 pt-0 pl-lg-3">
                 <article>
                     {{ .Content }}
                 </article>


### PR DESCRIPTION
+ smaller fonts
+ less white space between the menu and the text
+ numbered "bullets" in code examples
+ change the legend to hide table borders
+ make inline code blocks less pronounced
+ example titles style -> same as table titles 🙌
+ table titles should be at the top of the table
+ chapter headers proper top and bottom whitespaces
+ section headers as hyperlinks with anchor