### PR TITLE
Docs improvments and redesign

### DIFF
--- a/app/styles/_docs.scss
+++ b/app/styles/_docs.scss
@@ -102,8 +102,8 @@
   }
 
   // conum (callout nummber from code)
-  .conum[data-value],
-  .hljs-number {
+  // .hljs-number,
+  .conum[data-value] {
     // font-size: .875rem;
     // font-style: normal;
     // background: $body-color;
@@ -327,6 +327,11 @@
     font-weight: normal;
     margin-bottom: 10px;
     margin-top: 15px;
+  }
+
+  h1, h2, h3, h4, h5, h6,
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    position: relative;
   }
 
   h1, h2, h3, h4, h5, h6,

--- a/app/styles/_docs.scss
+++ b/app/styles/_docs.scss
@@ -419,4 +419,4 @@
     content: "\f0c1";
     opacity: 0;
     transition: all .2s linear;}
-}
+} 

--- a/app/styles/_docs.scss
+++ b/app/styles/_docs.scss
@@ -1,4 +1,5 @@
 .documentation-page {
+  font-size: .875rem;
 
   .toc {
     display: block !important; // overwrite docbook style
@@ -9,7 +10,7 @@
 
     .sectlevel2 {
         padding-left: 10px;
-        font-size: $small-font-size;
+        // font-size: $small-font-size;
     }
   }
 
@@ -22,7 +23,7 @@
   		// 0 level links
   		.cd-toc-link {
   			display: inline-block;
-  	        padding: .5rem 2rem .5rem .5rem;
+  	        padding: .5rem 2rem .5rem 0;
       		line-height: 1.1;
 
   			&.active {
@@ -32,10 +33,9 @@
 
   	    // Active states
   	    .nav-link {
+          // font-size: 0.95rem;
 
-            font-size: 0.95rem;
-
-  		    &.active {
+          &.active {
   		    	position: relative;
 
   		    	&:before {
@@ -69,7 +69,7 @@
 
   			// ul 1st level
   			.sectlevel1 {
-  				padding: 0 2rem 0 .75rem;
+  				padding: 0 2rem 0 0;
   				margin-bottom: 0;
   			}
 
@@ -182,9 +182,9 @@
 
     caption {
       color: #000;
-      font: italic 85%/1 arial, sans-serif;
+      font: italic 100%/1 arial, sans-serif;
       padding: 1em 0;
-      text-align: center;
+      caption-side: top;
     }
 
     td, th {
@@ -207,6 +207,12 @@
     tbody > tr:last-child > td {
       border-bottom-width: 0;
     }
+  }
+
+  .title {
+    color: #000;
+    font: italic 100%/1 arial, sans-serif;
+    padding: 1em 0 .75em;
   }
 }
 
@@ -302,6 +308,8 @@
     }
   }
 
+  
+
   h1 {
       text-align: center;
   }
@@ -335,12 +343,22 @@
 
   h2 {
     font-size:1.7rem;
+    margin-top: 0 !important;
+    margin-bottom: 0.5em !important;
+  }
+
+  * + .sect1 h2 {
+    margin-top: 3rem !important;
   }
 
   h3 {
     font-size: 1.4rem;
-    margin-bottom: 1rem;
-    margin-top: 3rem;
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  
+  .sect2:not(:first-child) h3 {
+    margin-top: 2rem !important;
   }
 
   h4 {

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -187,4 +187,4 @@ $code-font-size:                    100%;
 
 // FontAwesome
 
-$fa-font-path: "~@fortawesome/fontawesome-free/webfonts/";
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts/"; 

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -187,4 +187,4 @@ $code-font-size:                    100%;
 
 // FontAwesome
 
-$fa-font-path: "~@fortawesome/fontawesome-free/webfonts/"; 
+$fa-font-path: "~@fortawesome/fontawesome-free/webfonts/";

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -179,4 +179,12 @@ $modal-sm:                          300px !default;
 
 $modal-transition:                  transform .3s ease-out !default;
 
+
+// Code
+
+$code-font-size:                    100%;
+
+
+// FontAwesome
+
 $fa-font-path: "~@fortawesome/fontawesome-free/webfonts/";

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -194,8 +194,8 @@ $i: "../images/"; // PATH VAR
 		border-radius: calculateRem(5px);
 		display: inline-block;
 		overflow: visible;
-		padding: .05em .4em;
-		margin: .05em 0;
+		padding: 0em 0.4em;
+		line-height: 1.5;
 
 		a > &,
 		h1 > &, h2 > &, h3 > &, h4 > &, h5 > &, h6 > &,

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,4 +1,4 @@
-// GLOBAL SETTINGS
+// GLOBAL SETTINGS 
 @use "sass:math";
 
 $path-root: "..";

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -14,7 +14,7 @@
                 {{ partial "sidebar-single.gohtml" . }}
             </div>
 
-            <div class="col-12 col-lg-8 col-xl-9  pb-3 pt-0 pl-lg-3">
+            <div class="col-12 col-lg-8 col-xl-9   pb-3 pt-0 pl-lg-3">
                 <article>
                     {{ .Content }}
                 </article>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -9,12 +9,12 @@
             {{ partial "version_selector.gohtml" . }}
         <hr/>
 
-        <div class="row ">
+        <div class="row mx-0">
             <div id="docs-nav" class="col-12 col-lg-4 col-xl-3 nav  docs-nav">
                 {{ partial "sidebar-single.gohtml" . }}
             </div>
 
-            <div class="col-12 col-lg-8 col-xl-9  py-3 pl-lg-5">
+            <div class="col-12 col-lg-8 col-xl-9  pb-3 pt-0 pl-lg-3">
                 <article>
                     {{ .Content }}
                 </article>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -14,7 +14,7 @@
                 {{ partial "sidebar-single.gohtml" . }}
             </div>
 
-            <div class="col-12 col-lg-8 col-xl-9   pb-3 pt-0 pl-lg-3">
+            <div class="col-12 col-lg-8 col-xl-9  pb-3 pt-0 pl-lg-3">
                 <article>
                     {{ .Content }}
                 </article>


### PR DESCRIPTION
+ smaller fonts
+ less white space between the menu and the text
+ numbered "bullets" in code examples
+ change the legend to hide table borders
+ make inline code blocks less pronounced
+ example titles style -> same as table titles 🙌
+ table titles should be at the top of the table
+ chapter headers proper top and bottom whitespaces
+ section headers as hyperlinks with anchor

+ fixed anchors spreading all over the page
+ pre > code horizontal scroll